### PR TITLE
Fix problem with incomplete end sequences

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -87,7 +87,7 @@ class AnsiToHtmlConverter
     {
         $bg = 0;
         $fg = 7;
-        if ('0' != $ansi) {
+        if ('0' != $ansi && '' != $ansi) {
             $options = explode(';', $ansi);
 
             foreach ($options as $option) {
@@ -127,7 +127,7 @@ class AnsiToHtmlConverter
     protected function tokenize($text)
     {
         $tokens = array();
-        preg_match_all("/(?:\e\[(.+?)m|(\x08))/", $text, $matches, PREG_OFFSET_CAPTURE);
+        preg_match_all("/(?:\e\[(.*?)m|(\x08))/", $text, $matches, PREG_OFFSET_CAPTURE);
 
         $offset = 0;
         foreach ($matches[0] as $i => $match) {


### PR DESCRIPTION
Some terminals seem to not issue the complete end sequence '[0m' for returning to default color, but using a shorthand '[m', which can be fixed with a little tweak of the regular expression.
