### PR TITLE
fix convert underline to html style

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -72,16 +72,9 @@ class AnsiToHtmlConverter
         }
 
         if ($this->inlineStyles) {
-            $html = sprintf(
-                '<span style="background-color: %s; color: %s; text-decoration: none">%s</span>',
-                $this->inlineColors['black'], $this->inlineColors['white'],
-                $html
-            );
+            $html = sprintf('<span style="background-color: %s; color: %s">%s</span>', $this->inlineColors['black'], $this->inlineColors['white'], $html);
         } else {
-            $html = sprintf(
-                '<span class="ansi_color_fg_black ansi_color_bg_white" style="text-decoration: none">%s</span>',
-                $html
-            );
+            $html = sprintf('<span class="ansi_color_fg_black ansi_color_bg_white">%s</span>', $html);
         }
 
         // remove empty span
@@ -94,7 +87,7 @@ class AnsiToHtmlConverter
     {
         $bg = 0;
         $fg = 7;
-        $td = 'none';
+        $as = '';
         if ('0' != $ansi && '' != $ansi) {
             $options = explode(';', $ansi);
 
@@ -117,7 +110,7 @@ class AnsiToHtmlConverter
             }
 
             if (in_array(4, $options)) {
-                $td = 'underline';
+                $as = '; text-decoration: underline';
             }
 
             if (in_array(7, $options)) {
@@ -126,19 +119,9 @@ class AnsiToHtmlConverter
         }
 
         if ($this->inlineStyles) {
-            return sprintf(
-                '</span><span style="background-color: %s; color: %s; text-decoration: %s">',
-                $this->inlineColors[$this->colorNames[$bg]],
-                $this->inlineColors[$this->colorNames[$fg]],
-                $td
-            );
+            return sprintf('</span><span style="background-color: %s; color: %s%s">', $this->inlineColors[$this->colorNames[$bg]], $this->inlineColors[$this->colorNames[$fg]], $as);
         } else {
-            return sprintf(
-                '</span><span class="ansi_color_bg_%s ansi_color_fg_%s" style="text-decoration: %s">',
-                $this->colorNames[$bg],
-                $this->colorNames[$fg],
-                $td
-            );
+            return sprintf('</span><span class="ansi_color_bg_%s ansi_color_fg_%s">', $this->colorNames[$bg], $this->colorNames[$fg]);
         }
     }
 

--- a/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
@@ -28,26 +28,26 @@ class AnsiToHtmlConverterTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             // text is escaped
-            array('<span style="background-color: black; color: white; text-decoration: none">foo &lt;br /&gt;</span>', 'foo <br />'),
+            array('<span style="background-color: black; color: white">foo &lt;br /&gt;</span>', 'foo <br />'),
 
             // newlines are preserved
-            array("<span style=\"background-color: black; color: white; text-decoration: none\">foo\nbar</span>", "foo\nbar"),
+            array("<span style=\"background-color: black; color: white\">foo\nbar</span>", "foo\nbar"),
 
             // backspaces
-            array("<span style=\"background-color: black; color: white; text-decoration: none\">foo   </span>", "foobar\x08\x08\x08   "),
-            array("<span style=\"background-color: black; color: white; text-decoration: none\">foo</span><span style=\"background-color: black; color: white; text-decoration: none\">   </span>", "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+            array("<span style=\"background-color: black; color: white\">foo   </span>", "foobar\x08\x08\x08   "),
+            array("<span style=\"background-color: black; color: white\">foo</span><span style=\"background-color: black; color: white\">   </span>", "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
 
             // color
-            array("<span style=\"background-color: darkred; color: darkred; text-decoration: none\">foo</span>", "\e[31;41mfoo\e[0m"),
+            array("<span style=\"background-color: darkred; color: darkred\">foo</span>", "\e[31;41mfoo\e[0m"),
 
             // color with [m as a termination (equivalent to [0m])
-            array("<span style=\"background-color: darkred; color: darkred; text-decoration: none\">foo</span>", "\e[31;41mfoo\e[m"),
+            array("<span style=\"background-color: darkred; color: darkred\">foo</span>", "\e[31;41mfoo\e[m"),
 
             // bright color
-            array("<span style=\"background-color: red; color: red; text-decoration: none\">foo</span>", "\e[31;41;1mfoo\e[0m"),
+            array("<span style=\"background-color: red; color: red\">foo</span>", "\e[31;41;1mfoo\e[0m"),
 
             // carriage returns
-            array("<span style=\"background-color: black; color: white; text-decoration: none\">foobar</span>", "foo\rbar\rfoobar"),
+            array("<span style=\"background-color: black; color: white\">foobar</span>", "foo\rbar\rfoobar"),
 
             // underline
             array("<span style=\"background-color: black; color: white; text-decoration: underline\">foo</span>", "\e[4mfoo\e[0m"),


### PR DESCRIPTION
I had a problem with displaying results is Sismo.

```
( ! ) Notice: Undefined variable: text in Sismo/vendor/sensiolabs/ansi-to-html/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php on line 112
```

It turns out that converting underline to html isn't properly done so i made this fix.
