### PR TITLE
Make default colors for inline and class styles same

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -74,7 +74,7 @@ class AnsiToHtmlConverter
         if ($this->inlineStyles) {
             $html = sprintf('<span style="background-color: %s; color: %s">%s</span>', $this->inlineColors['black'], $this->inlineColors['white'], $html);
         } else {
-            $html = sprintf('<span class="ansi_color_fg_black ansi_color_bg_white">%s</span>', $html);
+            $html = sprintf('<span class="ansi_color_bg_black ansi_color_fg_white">%s</span>', $html);
         }
 
         // remove empty span


### PR DESCRIPTION
Hey,

I have changed classes in `span` wrapper to use same colors as when convertor uses inline styles.
