### PR TITLE
Adds replacement check for character set sequences

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -41,6 +41,9 @@ class AnsiToHtmlConverter
     {
         // remove cursor movement sequences
         $text = preg_replace('#\e\[(K|s|u|2J|2K|\d+(A|B|C|D|E|F|G|J|K|S|T)|\d+;\d+(H|f))#', '', $text);
+        // remove character set sequences
+        $text = preg_replace('#\e(\(|\))(A|B|[0-2])#', '', $text);
+
         $text = htmlspecialchars($text, PHP_VERSION_ID >= 50400 ? ENT_QUOTES | ENT_SUBSTITUTE : ENT_QUOTES, $this->charset);
 
         // carriage return


### PR DESCRIPTION
There's special escape sequences (for VT100) that alter character sets. These don't get replaced, like the cursor movements do.

Escape sequences such as:
```
\e(B
```

http://ascii-table.com/ansi-escape-sequences-vt-100.php

You can replicate the issue with the use of the command `tput sgr0`.