### PR TITLE
Support CSS prefix being defined early

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -23,10 +23,21 @@ class AnsiToHtmlConverter
     protected $inlineStyles;
     protected $inlineColors;
     protected $colorNames;
+    protected $cssPrefix;
 
-    public function __construct(Theme $theme = null, $inlineStyles = true, $charset = 'UTF-8')
+    public function __construct(Theme $theme = null, $inlineStyles = true, $charset = 'UTF-8', $cssPrefix = 'ansi_color')
     {
-        $this->theme = null === $theme ? new Theme() : $theme;
+        if (is_null($theme)) {
+            $this->theme = new Theme($cssPrefix);
+            $this->cssPrefix = $cssPrefix;
+        } else {
+            $this->theme = $theme;
+            $this->cssPrefix = $theme->getPrefix();
+            if (is_null($this->cssPrefix)) {
+                $this->theme->setPrefix($cssPrefix);
+                $this->cssPrefix = $cssPrefix;
+            }
+        }
         $this->inlineStyles = $inlineStyles;
         $this->charset = $charset;
         $this->inlineColors = $this->theme->asArray();
@@ -74,7 +85,7 @@ class AnsiToHtmlConverter
         if ($this->inlineStyles) {
             $html = sprintf('<span style="background-color: %s; color: %s">%s</span>', $this->inlineColors['black'], $this->inlineColors['white'], $html);
         } else {
-            $html = sprintf('<span class="ansi_color_bg_black ansi_color_fg_white">%s</span>', $html);
+            $html = sprintf('<span class="%1$s_bg_black %1$s_fg_white">%2$s</span>', $this->cssPrefix, $html);
         }
 
         // remove empty span
@@ -126,9 +137,20 @@ class AnsiToHtmlConverter
         }
 
         if ($this->inlineStyles) {
-            return sprintf('</span><span style="background-color: %s; color: %s%s">', $this->inlineColors[$this->colorNames[$bg]], $this->inlineColors[$this->colorNames[$fg]], $as);
+            return sprintf(
+                '</span><span style="background-color: %s; color: %s%s">',
+                $this->inlineColors[$this->colorNames[$bg]],
+                $this->inlineColors[$this->colorNames[$fg]],
+                $as
+            );
         } else {
-            return sprintf('</span><span class="ansi_color_bg_%s ansi_color_fg_%s">', $this->colorNames[$bg], $this->colorNames[$fg]);
+            return sprintf(
+                '</span><span class="%1$s_bg_%2$s %1$s_fg_%3$s%4$s">',
+                $this->cssPrefix,
+                $this->colorNames[$bg],
+                $this->colorNames[$fg],
+                ($as ? sprintf(' %1$s_underlined', $this->cssPrefix) : '')
+            );
         }
     }
 

--- a/SensioLabs/AnsiConverter/Tests/AlternativeTheme/AnsiToHtmlConverterWithAlternativeCSSPrefixTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AlternativeTheme/AnsiToHtmlConverterWithAlternativeCSSPrefixTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Tests\AlternativeTheme;
+
+use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+use SensioLabs\AnsiConverter\Theme\SolarizedXTermTheme;
+
+class AnsiToHtmlConverterWithAlternativeCSSPrefixTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getConvertData
+     */
+    public function testConvert($expectedOutput, $expectedCss, $input)
+    {
+        $converter = new AnsiToHtmlConverter(new SolarizedXTermTheme(), false, 'UTF-8', 'alternative_prefix');
+        $this->assertEquals($expectedOutput, $converter->convert($input));
+        $this->assertEquals($expectedCss, $converter->getTheme()->asCss());
+    }
+
+    public function getConvertData()
+    {
+        $css = <<< 'END_CSS'
+.alternative_prefix_fg_black { color: #262626 }
+.alternative_prefix_bg_black { background-color: #262626 }
+.alternative_prefix_fg_red { color: #d70000 }
+.alternative_prefix_bg_red { background-color: #d70000 }
+.alternative_prefix_fg_green { color: #5f8700 }
+.alternative_prefix_bg_green { background-color: #5f8700 }
+.alternative_prefix_fg_yellow { color: #af8700 }
+.alternative_prefix_bg_yellow { background-color: #af8700 }
+.alternative_prefix_fg_blue { color: #0087ff }
+.alternative_prefix_bg_blue { background-color: #0087ff }
+.alternative_prefix_fg_magenta { color: #af005f }
+.alternative_prefix_bg_magenta { background-color: #af005f }
+.alternative_prefix_fg_cyan { color: #00afaf }
+.alternative_prefix_bg_cyan { background-color: #00afaf }
+.alternative_prefix_fg_white { color: #e4e4e4 }
+.alternative_prefix_bg_white { background-color: #e4e4e4 }
+.alternative_prefix_fg_brblack { color: #1c1c1c }
+.alternative_prefix_bg_brblack { background-color: #1c1c1c }
+.alternative_prefix_fg_brred { color: #d75f00 }
+.alternative_prefix_bg_brred { background-color: #d75f00 }
+.alternative_prefix_fg_brgreen { color: #585858 }
+.alternative_prefix_bg_brgreen { background-color: #585858 }
+.alternative_prefix_fg_bryellow { color: #626262 }
+.alternative_prefix_bg_bryellow { background-color: #626262 }
+.alternative_prefix_fg_brblue { color: #808080 }
+.alternative_prefix_bg_brblue { background-color: #808080 }
+.alternative_prefix_fg_brmagenta { color: #5f5faf }
+.alternative_prefix_bg_brmagenta { background-color: #5f5faf }
+.alternative_prefix_fg_brcyan { color: #8a8a8a }
+.alternative_prefix_bg_brcyan { background-color: #8a8a8a }
+.alternative_prefix_fg_brwhite { color: #ffffd7 }
+.alternative_prefix_bg_brwhite { background-color: #ffffd7 }
+.alternative_prefix_underlined { text-decoration: underlined }
+END_CSS;
+
+        return array(
+            // text is escaped
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foo &lt;br /&gt;</span>', $css, 'foo <br />'),
+
+            // newlines are preserved
+            array("<span class=\"alternative_prefix_bg_black alternative_prefix_fg_white\">foo\nbar</span>", $css, "foo\nbar"),
+
+            // backspaces
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foo   </span>', $css, "foobar\x08\x08\x08   "),
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foo</span><span class="alternative_prefix_bg_black alternative_prefix_fg_white">   </span>', $css, "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+
+            // color
+            array('<span class="alternative_prefix_bg_red alternative_prefix_fg_red">foo</span>', $css, "\e[31;41mfoo\e[0m"),
+
+            // color with [m as a termination (equivalent to [0m])
+            array('<span class="alternative_prefix_bg_red alternative_prefix_fg_red">foo</span>', $css, "\e[31;41mfoo\e[m"),
+
+            // bright color
+            array('<span class="alternative_prefix_bg_brred alternative_prefix_fg_brred">foo</span>', $css, "\e[31;41;1mfoo\e[0m"),
+
+            // carriage returns
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foobar</span>', $css, "foo\rbar\rfoobar"),
+
+            // underline
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white alternative_prefix_underlined">foo</span>', $css, "\e[4mfoo\e[0m"),
+
+            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
+            PHP_VERSION_ID < 50400 ?: array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foo '."\xEF\xBF\xBD".'</span>', $css, "foo \xF4\xFF\xFF\xFF"),
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Tests/AlternativeTheme/AnsiToHtmlConverterWithClassesTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AlternativeTheme/AnsiToHtmlConverterWithClassesTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Tests\AlternativeTheme;
+
+use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+use SensioLabs\AnsiConverter\Theme\SolarizedXTermTheme;
+
+class AnsiToHtmlConverterWithClassesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getConvertData
+     */
+    public function testConvert($expectedOutput, $expectedCss, $input)
+    {
+        $converter = new AnsiToHtmlConverter(new SolarizedXTermTheme(), false);
+        $this->assertEquals($expectedOutput, $converter->convert($input));
+        $this->assertEquals($expectedCss, $converter->getTheme()->asCss());
+    }
+
+    public function getConvertData()
+    {
+        $css = <<< 'END_CSS'
+.ansi_color_fg_black { color: #262626 }
+.ansi_color_bg_black { background-color: #262626 }
+.ansi_color_fg_red { color: #d70000 }
+.ansi_color_bg_red { background-color: #d70000 }
+.ansi_color_fg_green { color: #5f8700 }
+.ansi_color_bg_green { background-color: #5f8700 }
+.ansi_color_fg_yellow { color: #af8700 }
+.ansi_color_bg_yellow { background-color: #af8700 }
+.ansi_color_fg_blue { color: #0087ff }
+.ansi_color_bg_blue { background-color: #0087ff }
+.ansi_color_fg_magenta { color: #af005f }
+.ansi_color_bg_magenta { background-color: #af005f }
+.ansi_color_fg_cyan { color: #00afaf }
+.ansi_color_bg_cyan { background-color: #00afaf }
+.ansi_color_fg_white { color: #e4e4e4 }
+.ansi_color_bg_white { background-color: #e4e4e4 }
+.ansi_color_fg_brblack { color: #1c1c1c }
+.ansi_color_bg_brblack { background-color: #1c1c1c }
+.ansi_color_fg_brred { color: #d75f00 }
+.ansi_color_bg_brred { background-color: #d75f00 }
+.ansi_color_fg_brgreen { color: #585858 }
+.ansi_color_bg_brgreen { background-color: #585858 }
+.ansi_color_fg_bryellow { color: #626262 }
+.ansi_color_bg_bryellow { background-color: #626262 }
+.ansi_color_fg_brblue { color: #808080 }
+.ansi_color_bg_brblue { background-color: #808080 }
+.ansi_color_fg_brmagenta { color: #5f5faf }
+.ansi_color_bg_brmagenta { background-color: #5f5faf }
+.ansi_color_fg_brcyan { color: #8a8a8a }
+.ansi_color_bg_brcyan { background-color: #8a8a8a }
+.ansi_color_fg_brwhite { color: #ffffd7 }
+.ansi_color_bg_brwhite { background-color: #ffffd7 }
+.ansi_color_underlined { text-decoration: underlined }
+END_CSS;
+
+        return array(
+            // text is escaped
+            array('<span class="ansi_color_bg_black ansi_color_fg_white">foo &lt;br /&gt;</span>', $css, 'foo <br />'),
+
+            // newlines are preserved
+            array("<span class=\"ansi_color_bg_black ansi_color_fg_white\">foo\nbar</span>", $css, "foo\nbar"),
+
+            // backspaces
+            array('<span class="ansi_color_bg_black ansi_color_fg_white">foo   </span>', $css, "foobar\x08\x08\x08   "),
+            array('<span class="ansi_color_bg_black ansi_color_fg_white">foo</span><span class="ansi_color_bg_black ansi_color_fg_white">   </span>', $css, "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+
+            // color
+            array('<span class="ansi_color_bg_red ansi_color_fg_red">foo</span>', $css, "\e[31;41mfoo\e[0m"),
+
+            // color with [m as a termination (equivalent to [0m])
+            array('<span class="ansi_color_bg_red ansi_color_fg_red">foo</span>', $css, "\e[31;41mfoo\e[m"),
+
+            // bright color
+            array('<span class="ansi_color_bg_brred ansi_color_fg_brred">foo</span>', $css, "\e[31;41;1mfoo\e[0m"),
+
+            // carriage returns
+            array('<span class="ansi_color_bg_black ansi_color_fg_white">foobar</span>', $css, "foo\rbar\rfoobar"),
+
+            // underline
+            array('<span class="ansi_color_bg_black ansi_color_fg_white ansi_color_underlined">foo</span>', $css, "\e[4mfoo\e[0m"),
+
+            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
+            PHP_VERSION_ID < 50400 ?: array('<span class="ansi_color_bg_black ansi_color_fg_white">foo '."\xEF\xBF\xBD".'</span>', $css, "foo \xF4\xFF\xFF\xFF"),
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Tests/AlternativeTheme/AnsiToHtmlConverterWithInlineStylesTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AlternativeTheme/AnsiToHtmlConverterWithInlineStylesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Tests\AlternativeTheme;
+
+use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+use SensioLabs\AnsiConverter\Theme\SolarizedXTermTheme;
+
+class AnsiToHtmlConverterWithInlineStylesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getConvertData
+     */
+    public function testConvertWith($expected, $input)
+    {
+        $converter = new AnsiToHtmlConverter(new SolarizedXTermTheme());
+        $this->assertEquals($expected, $converter->convert($input));
+    }
+
+    public function getConvertData()
+    {
+        return array(
+            // text is escaped
+            array('<span style="background-color: #262626; color: #e4e4e4">foo &lt;br /&gt;</span>', 'foo <br />'),
+
+            // newlines are preserved
+            array("<span style=\"background-color: #262626; color: #e4e4e4\">foo\nbar</span>", "foo\nbar"),
+
+            // backspaces
+            array('<span style="background-color: #262626; color: #e4e4e4">foo   </span>', "foobar\x08\x08\x08   "),
+            array('<span style="background-color: #262626; color: #e4e4e4">foo</span><span style="background-color: #262626; color: #e4e4e4">   </span>', "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+
+            // color
+            array('<span style="background-color: #d70000; color: #d70000">foo</span>', "\e[31;41mfoo\e[0m"),
+
+            // color with [m as a termination (equivalent to [0m])
+            array('<span style="background-color: #d70000; color: #d70000">foo</span>', "\e[31;41mfoo\e[m"),
+
+            // bright color
+            array('<span style="background-color: #d75f00; color: #d75f00">foo</span>', "\e[31;41;1mfoo\e[0m"),
+
+            // carriage returns
+            array('<span style="background-color: #262626; color: #e4e4e4">foobar</span>', "foo\rbar\rfoobar"),
+
+            // underline
+            array('<span style="background-color: #262626; color: #e4e4e4; text-decoration: underline">foo</span>', "\e[4mfoo\e[0m"),
+
+            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
+            PHP_VERSION_ID < 50400 ?: array('<span style="background-color: #262626; color: #e4e4e4">foo '."\xEF\xBF\xBD".'</span>', "foo \xF4\xFF\xFF\xFF"),
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Tests/AlternativeThemeWithOwnPrefix/AnsiToHtmlConverterWithAlternativeCSSPrefixTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AlternativeThemeWithOwnPrefix/AnsiToHtmlConverterWithAlternativeCSSPrefixTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Tests\AlternativeThemeWithOwnPrefix;
+
+use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+use SensioLabs\AnsiConverter\Theme\SolarizedXTermTheme;
+
+class AnsiToHtmlConverterWithAlternativeCSSPrefixTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getConvertData
+     */
+    public function testConvert($expectedOutput, $expectedCss, $input)
+    {
+        $converter = new AnsiToHtmlConverter(new SolarizedXTermTheme('solarized'), false, 'UTF-8', 'alternative_prefix');
+        $this->assertEquals($expectedOutput, $converter->convert($input));
+        $this->assertEquals($expectedCss, $converter->getTheme()->asCss());
+    }
+
+    public function getConvertData()
+    {
+        $css = <<< 'END_CSS'
+.solarized_fg_black { color: #262626 }
+.solarized_bg_black { background-color: #262626 }
+.solarized_fg_red { color: #d70000 }
+.solarized_bg_red { background-color: #d70000 }
+.solarized_fg_green { color: #5f8700 }
+.solarized_bg_green { background-color: #5f8700 }
+.solarized_fg_yellow { color: #af8700 }
+.solarized_bg_yellow { background-color: #af8700 }
+.solarized_fg_blue { color: #0087ff }
+.solarized_bg_blue { background-color: #0087ff }
+.solarized_fg_magenta { color: #af005f }
+.solarized_bg_magenta { background-color: #af005f }
+.solarized_fg_cyan { color: #00afaf }
+.solarized_bg_cyan { background-color: #00afaf }
+.solarized_fg_white { color: #e4e4e4 }
+.solarized_bg_white { background-color: #e4e4e4 }
+.solarized_fg_brblack { color: #1c1c1c }
+.solarized_bg_brblack { background-color: #1c1c1c }
+.solarized_fg_brred { color: #d75f00 }
+.solarized_bg_brred { background-color: #d75f00 }
+.solarized_fg_brgreen { color: #585858 }
+.solarized_bg_brgreen { background-color: #585858 }
+.solarized_fg_bryellow { color: #626262 }
+.solarized_bg_bryellow { background-color: #626262 }
+.solarized_fg_brblue { color: #808080 }
+.solarized_bg_brblue { background-color: #808080 }
+.solarized_fg_brmagenta { color: #5f5faf }
+.solarized_bg_brmagenta { background-color: #5f5faf }
+.solarized_fg_brcyan { color: #8a8a8a }
+.solarized_bg_brcyan { background-color: #8a8a8a }
+.solarized_fg_brwhite { color: #ffffd7 }
+.solarized_bg_brwhite { background-color: #ffffd7 }
+.solarized_underlined { text-decoration: underlined }
+END_CSS;
+
+        return array(
+            // text is escaped
+            array('<span class="solarized_bg_black solarized_fg_white">foo &lt;br /&gt;</span>', $css, 'foo <br />'),
+
+            // newlines are preserved
+            array("<span class=\"solarized_bg_black solarized_fg_white\">foo\nbar</span>", $css, "foo\nbar"),
+
+            // backspaces
+            array('<span class="solarized_bg_black solarized_fg_white">foo   </span>', $css, "foobar\x08\x08\x08   "),
+            array('<span class="solarized_bg_black solarized_fg_white">foo</span><span class="solarized_bg_black solarized_fg_white">   </span>', $css, "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+
+            // color
+            array('<span class="solarized_bg_red solarized_fg_red">foo</span>', $css, "\e[31;41mfoo\e[0m"),
+
+            // color with [m as a termination (equivalent to [0m])
+            array('<span class="solarized_bg_red solarized_fg_red">foo</span>', $css, "\e[31;41mfoo\e[m"),
+
+            // bright color
+            array('<span class="solarized_bg_brred solarized_fg_brred">foo</span>', $css, "\e[31;41;1mfoo\e[0m"),
+
+            // carriage returns
+            array('<span class="solarized_bg_black solarized_fg_white">foobar</span>', $css, "foo\rbar\rfoobar"),
+
+            // underline
+            array('<span class="solarized_bg_black solarized_fg_white solarized_underlined">foo</span>', $css, "\e[4mfoo\e[0m"),
+
+            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
+            PHP_VERSION_ID < 50400 ?: array('<span class="solarized_bg_black solarized_fg_white">foo '."\xEF\xBF\xBD".'</span>', $css, "foo \xF4\xFF\xFF\xFF"),
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Tests/AlternativeThemeWithOwnPrefix/AnsiToHtmlConverterWithClassesTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AlternativeThemeWithOwnPrefix/AnsiToHtmlConverterWithClassesTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Tests\AlternativeThemeWithOwnPrefix;
+
+use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+use SensioLabs\AnsiConverter\Theme\SolarizedXTermTheme;
+
+class AnsiToHtmlConverterWithClassesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getConvertData
+     */
+    public function testConvert($expectedOutput, $expectedCss, $input)
+    {
+        $converter = new AnsiToHtmlConverter(new SolarizedXTermTheme('solarized'), false);
+        $this->assertEquals($expectedOutput, $converter->convert($input));
+        $this->assertEquals($expectedCss, $converter->getTheme()->asCss());
+    }
+
+    public function getConvertData()
+    {
+        $css = <<< 'END_CSS'
+.solarized_fg_black { color: #262626 }
+.solarized_bg_black { background-color: #262626 }
+.solarized_fg_red { color: #d70000 }
+.solarized_bg_red { background-color: #d70000 }
+.solarized_fg_green { color: #5f8700 }
+.solarized_bg_green { background-color: #5f8700 }
+.solarized_fg_yellow { color: #af8700 }
+.solarized_bg_yellow { background-color: #af8700 }
+.solarized_fg_blue { color: #0087ff }
+.solarized_bg_blue { background-color: #0087ff }
+.solarized_fg_magenta { color: #af005f }
+.solarized_bg_magenta { background-color: #af005f }
+.solarized_fg_cyan { color: #00afaf }
+.solarized_bg_cyan { background-color: #00afaf }
+.solarized_fg_white { color: #e4e4e4 }
+.solarized_bg_white { background-color: #e4e4e4 }
+.solarized_fg_brblack { color: #1c1c1c }
+.solarized_bg_brblack { background-color: #1c1c1c }
+.solarized_fg_brred { color: #d75f00 }
+.solarized_bg_brred { background-color: #d75f00 }
+.solarized_fg_brgreen { color: #585858 }
+.solarized_bg_brgreen { background-color: #585858 }
+.solarized_fg_bryellow { color: #626262 }
+.solarized_bg_bryellow { background-color: #626262 }
+.solarized_fg_brblue { color: #808080 }
+.solarized_bg_brblue { background-color: #808080 }
+.solarized_fg_brmagenta { color: #5f5faf }
+.solarized_bg_brmagenta { background-color: #5f5faf }
+.solarized_fg_brcyan { color: #8a8a8a }
+.solarized_bg_brcyan { background-color: #8a8a8a }
+.solarized_fg_brwhite { color: #ffffd7 }
+.solarized_bg_brwhite { background-color: #ffffd7 }
+.solarized_underlined { text-decoration: underlined }
+END_CSS;
+
+        return array(
+            // text is escaped
+            array('<span class="solarized_bg_black solarized_fg_white">foo &lt;br /&gt;</span>', $css, 'foo <br />'),
+
+            // newlines are preserved
+            array("<span class=\"solarized_bg_black solarized_fg_white\">foo\nbar</span>", $css, "foo\nbar"),
+
+            // backspaces
+            array('<span class="solarized_bg_black solarized_fg_white">foo   </span>', $css, "foobar\x08\x08\x08   "),
+            array('<span class="solarized_bg_black solarized_fg_white">foo</span><span class="solarized_bg_black solarized_fg_white">   </span>', $css, "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+
+            // color
+            array('<span class="solarized_bg_red solarized_fg_red">foo</span>', $css, "\e[31;41mfoo\e[0m"),
+
+            // color with [m as a termination (equivalent to [0m])
+            array('<span class="solarized_bg_red solarized_fg_red">foo</span>', $css, "\e[31;41mfoo\e[m"),
+
+            // bright color
+            array('<span class="solarized_bg_brred solarized_fg_brred">foo</span>', $css, "\e[31;41;1mfoo\e[0m"),
+
+            // carriage returns
+            array('<span class="solarized_bg_black solarized_fg_white">foobar</span>', $css, "foo\rbar\rfoobar"),
+
+            // underline
+            array('<span class="solarized_bg_black solarized_fg_white solarized_underlined">foo</span>', $css, "\e[4mfoo\e[0m"),
+
+            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
+            PHP_VERSION_ID < 50400 ?: array('<span class="solarized_bg_black solarized_fg_white">foo '."\xEF\xBF\xBD".'</span>', $css, "foo \xF4\xFF\xFF\xFF"),
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Tests/AlternativeThemeWithOwnPrefix/AnsiToHtmlConverterWithInlineStylesTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AlternativeThemeWithOwnPrefix/AnsiToHtmlConverterWithInlineStylesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Tests\AlternativeThemeWithOwnPrefix;
+
+use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+use SensioLabs\AnsiConverter\Theme\SolarizedXTermTheme;
+
+class AnsiToHtmlConverterWithInlineStylesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getConvertData
+     */
+    public function testConvertWith($expected, $input)
+    {
+        $converter = new AnsiToHtmlConverter(new SolarizedXTermTheme('solarized'));
+        $this->assertEquals($expected, $converter->convert($input));
+    }
+
+    public function getConvertData()
+    {
+        return array(
+            // text is escaped
+            array('<span style="background-color: #262626; color: #e4e4e4">foo &lt;br /&gt;</span>', 'foo <br />'),
+
+            // newlines are preserved
+            array("<span style=\"background-color: #262626; color: #e4e4e4\">foo\nbar</span>", "foo\nbar"),
+
+            // backspaces
+            array('<span style="background-color: #262626; color: #e4e4e4">foo   </span>', "foobar\x08\x08\x08   "),
+            array('<span style="background-color: #262626; color: #e4e4e4">foo</span><span style="background-color: #262626; color: #e4e4e4">   </span>', "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+
+            // color
+            array('<span style="background-color: #d70000; color: #d70000">foo</span>', "\e[31;41mfoo\e[0m"),
+
+            // color with [m as a termination (equivalent to [0m])
+            array('<span style="background-color: #d70000; color: #d70000">foo</span>', "\e[31;41mfoo\e[m"),
+
+            // bright color
+            array('<span style="background-color: #d75f00; color: #d75f00">foo</span>', "\e[31;41;1mfoo\e[0m"),
+
+            // carriage returns
+            array('<span style="background-color: #262626; color: #e4e4e4">foobar</span>', "foo\rbar\rfoobar"),
+
+            // underline
+            array('<span style="background-color: #262626; color: #e4e4e4; text-decoration: underline">foo</span>', "\e[4mfoo\e[0m"),
+
+            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
+            PHP_VERSION_ID < 50400 ?: array('<span style="background-color: #262626; color: #e4e4e4">foo '."\xEF\xBF\xBD".'</span>', "foo \xF4\xFF\xFF\xFF"),
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Tests/DefaultTheme/AnsiToHtmlConverterWithAlternativeCSSPrefixTest.php
+++ b/SensioLabs/AnsiConverter/Tests/DefaultTheme/AnsiToHtmlConverterWithAlternativeCSSPrefixTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Tests\DefaultTheme;
+
+use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+
+class AnsiToHtmlConverterWithAlternativeCSSPrefixTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getConvertData
+     */
+    public function testConvert($expectedOutput, $expectedCss, $input)
+    {
+        $converter = new AnsiToHtmlConverter(null, false, 'UTF-8', 'alternative_prefix');
+        $this->assertEquals($expectedOutput, $converter->convert($input));
+        $this->assertEquals($expectedCss, $converter->getTheme()->asCss());
+    }
+
+    public function getConvertData()
+    {
+        $css = <<< 'END_CSS'
+.alternative_prefix_fg_black { color: black }
+.alternative_prefix_bg_black { background-color: black }
+.alternative_prefix_fg_red { color: darkred }
+.alternative_prefix_bg_red { background-color: darkred }
+.alternative_prefix_fg_green { color: green }
+.alternative_prefix_bg_green { background-color: green }
+.alternative_prefix_fg_yellow { color: yellow }
+.alternative_prefix_bg_yellow { background-color: yellow }
+.alternative_prefix_fg_blue { color: blue }
+.alternative_prefix_bg_blue { background-color: blue }
+.alternative_prefix_fg_magenta { color: darkmagenta }
+.alternative_prefix_bg_magenta { background-color: darkmagenta }
+.alternative_prefix_fg_cyan { color: cyan }
+.alternative_prefix_bg_cyan { background-color: cyan }
+.alternative_prefix_fg_white { color: white }
+.alternative_prefix_bg_white { background-color: white }
+.alternative_prefix_fg_brblack { color: black }
+.alternative_prefix_bg_brblack { background-color: black }
+.alternative_prefix_fg_brred { color: red }
+.alternative_prefix_bg_brred { background-color: red }
+.alternative_prefix_fg_brgreen { color: lightgreen }
+.alternative_prefix_bg_brgreen { background-color: lightgreen }
+.alternative_prefix_fg_bryellow { color: lightyellow }
+.alternative_prefix_bg_bryellow { background-color: lightyellow }
+.alternative_prefix_fg_brblue { color: lightblue }
+.alternative_prefix_bg_brblue { background-color: lightblue }
+.alternative_prefix_fg_brmagenta { color: magenta }
+.alternative_prefix_bg_brmagenta { background-color: magenta }
+.alternative_prefix_fg_brcyan { color: lightcyan }
+.alternative_prefix_bg_brcyan { background-color: lightcyan }
+.alternative_prefix_fg_brwhite { color: white }
+.alternative_prefix_bg_brwhite { background-color: white }
+.alternative_prefix_underlined { text-decoration: underlined }
+END_CSS;
+
+        return array(
+            // text is escaped
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foo &lt;br /&gt;</span>', $css, 'foo <br />'),
+
+            // newlines are preserved
+            array("<span class=\"alternative_prefix_bg_black alternative_prefix_fg_white\">foo\nbar</span>", $css, "foo\nbar"),
+
+            // backspaces
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foo   </span>', $css, "foobar\x08\x08\x08   "),
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foo</span><span class="alternative_prefix_bg_black alternative_prefix_fg_white">   </span>', $css, "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+
+            // color
+            array('<span class="alternative_prefix_bg_red alternative_prefix_fg_red">foo</span>', $css, "\e[31;41mfoo\e[0m"),
+
+            // color with [m as a termination (equivalent to [0m])
+            array('<span class="alternative_prefix_bg_red alternative_prefix_fg_red">foo</span>', $css, "\e[31;41mfoo\e[m"),
+
+            // bright color
+            array('<span class="alternative_prefix_bg_brred alternative_prefix_fg_brred">foo</span>', $css, "\e[31;41;1mfoo\e[0m"),
+
+            // carriage returns
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foobar</span>', $css, "foo\rbar\rfoobar"),
+
+            // underline
+            array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white alternative_prefix_underlined">foo</span>', $css, "\e[4mfoo\e[0m"),
+
+            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
+            PHP_VERSION_ID < 50400 ?: array('<span class="alternative_prefix_bg_black alternative_prefix_fg_white">foo '."\xEF\xBF\xBD".'</span>', $css, "foo \xF4\xFF\xFF\xFF"),
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Tests/DefaultTheme/AnsiToHtmlConverterWithClassesTest.php
+++ b/SensioLabs/AnsiConverter/Tests/DefaultTheme/AnsiToHtmlConverterWithClassesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Tests\DefaultTheme;
+
+use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
+
+class AnsiToHtmlConverterWithClassesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getConvertData
+     */
+    public function testConvert($expectedOutput, $expectedCss, $input)
+    {
+        $converter = new AnsiToHtmlConverter(null, false);
+        $this->assertEquals($expectedOutput, $converter->convert($input));
+        $this->assertEquals($expectedCss, $converter->getTheme()->asCss());
+    }
+
+    public function getConvertData()
+    {
+        $css = <<< 'END_CSS'
+.ansi_color_fg_black { color: black }
+.ansi_color_bg_black { background-color: black }
+.ansi_color_fg_red { color: darkred }
+.ansi_color_bg_red { background-color: darkred }
+.ansi_color_fg_green { color: green }
+.ansi_color_bg_green { background-color: green }
+.ansi_color_fg_yellow { color: yellow }
+.ansi_color_bg_yellow { background-color: yellow }
+.ansi_color_fg_blue { color: blue }
+.ansi_color_bg_blue { background-color: blue }
+.ansi_color_fg_magenta { color: darkmagenta }
+.ansi_color_bg_magenta { background-color: darkmagenta }
+.ansi_color_fg_cyan { color: cyan }
+.ansi_color_bg_cyan { background-color: cyan }
+.ansi_color_fg_white { color: white }
+.ansi_color_bg_white { background-color: white }
+.ansi_color_fg_brblack { color: black }
+.ansi_color_bg_brblack { background-color: black }
+.ansi_color_fg_brred { color: red }
+.ansi_color_bg_brred { background-color: red }
+.ansi_color_fg_brgreen { color: lightgreen }
+.ansi_color_bg_brgreen { background-color: lightgreen }
+.ansi_color_fg_bryellow { color: lightyellow }
+.ansi_color_bg_bryellow { background-color: lightyellow }
+.ansi_color_fg_brblue { color: lightblue }
+.ansi_color_bg_brblue { background-color: lightblue }
+.ansi_color_fg_brmagenta { color: magenta }
+.ansi_color_bg_brmagenta { background-color: magenta }
+.ansi_color_fg_brcyan { color: lightcyan }
+.ansi_color_bg_brcyan { background-color: lightcyan }
+.ansi_color_fg_brwhite { color: white }
+.ansi_color_bg_brwhite { background-color: white }
+.ansi_color_underlined { text-decoration: underlined }
+END_CSS;
+
+        return array(
+            // text is escaped
+            array('<span class="ansi_color_bg_black ansi_color_fg_white">foo &lt;br /&gt;</span>', $css, 'foo <br />'),
+
+            // newlines are preserved
+            array("<span class=\"ansi_color_bg_black ansi_color_fg_white\">foo\nbar</span>", $css, "foo\nbar"),
+
+            // backspaces
+            array('<span class="ansi_color_bg_black ansi_color_fg_white">foo   </span>', $css, "foobar\x08\x08\x08   "),
+            array('<span class="ansi_color_bg_black ansi_color_fg_white">foo</span><span class="ansi_color_bg_black ansi_color_fg_white">   </span>', $css, "foob\e[31;41ma\e[0mr\x08\x08\x08   "),
+
+            // color
+            array('<span class="ansi_color_bg_red ansi_color_fg_red">foo</span>', $css, "\e[31;41mfoo\e[0m"),
+
+            // color with [m as a termination (equivalent to [0m])
+            array('<span class="ansi_color_bg_red ansi_color_fg_red">foo</span>', $css, "\e[31;41mfoo\e[m"),
+
+            // bright color
+            array('<span class="ansi_color_bg_brred ansi_color_fg_brred">foo</span>', $css, "\e[31;41;1mfoo\e[0m"),
+
+            // carriage returns
+            array('<span class="ansi_color_bg_black ansi_color_fg_white">foobar</span>', $css, "foo\rbar\rfoobar"),
+
+            // underline
+            array('<span class="ansi_color_bg_black ansi_color_fg_white ansi_color_underlined">foo</span>', $css, "\e[4mfoo\e[0m"),
+
+            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
+            PHP_VERSION_ID < 50400 ?: array('<span class="ansi_color_bg_black ansi_color_fg_white">foo '."\xEF\xBF\xBD".'</span>', $css, "foo \xF4\xFF\xFF\xFF"),
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Tests/DefaultTheme/AnsiToHtmlConverterWithInlineStylesTest.php
+++ b/SensioLabs/AnsiConverter/Tests/DefaultTheme/AnsiToHtmlConverterWithInlineStylesTest.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\AnsiConverter\Tests;
+namespace SensioLabs\AnsiConverter\Tests\DefaultTheme;
 
 use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
 
-class AnsiToHtmlConverterTest extends \PHPUnit_Framework_TestCase
+class AnsiToHtmlConverterWithInlineStylesTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider getConvertData

--- a/SensioLabs/AnsiConverter/Theme/Theme.php
+++ b/SensioLabs/AnsiConverter/Theme/Theme.php
@@ -16,13 +16,24 @@ namespace SensioLabs\AnsiConverter\Theme;
  */
 class Theme
 {
-    public function asCss($prefix = 'ansi_color')
+    /**
+     * @var string
+     */
+    protected $prefix;
+
+    public function __construct($prefix = null)
+    {
+        $this->prefix = $prefix;
+    }
+
+    public function asCss()
     {
         $css = array();
         foreach ($this->asArray() as $name => $color) {
-            $css[] = sprintf('.%s_fg_%s { color: %s }', $prefix, $name, $color);
-            $css[] = sprintf('.%s_bg_%s { background-color: %s }', $prefix, $name, $color);
+            $css[] = sprintf('.%s_fg_%s { color: %s }', $this->prefix, $name, $color);
+            $css[] = sprintf('.%s_bg_%s { background-color: %s }', $this->prefix, $name, $color);
         }
+        $css[] = sprintf('.%s_underlined { text-decoration: underlined }', $this->prefix);
 
         return implode("\n", $css);
     }
@@ -48,5 +59,21 @@ class Theme
             'brcyan' => 'lightcyan',
             'brwhite' => 'white',
         );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @param string $prefix
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
     }
 }


### PR DESCRIPTION
The CSS prefix that is part of the theme takes precedence over the prefix
supplied to the converter.

Deprecates $prefix parameter from Theme::asCss()

It would be cumbersome to support a dynamic prefix at this late stage of
the rendering.

Tests updated to cover the following combinations.

1. Using the default theme or a supplied theme, with and without its own css prefix.
2. Using the default css prefix or a supplied prefix.
3. Using inline styling or CSS.

Hopefully fixes https://github.com/sensiolabs/ansi-to-html/issues/12