### PR TITLE
Create an ESM Browser ready build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,21 @@
+import resolve from "rollup-plugin-node-resolve";
+import commonjs from "rollup-plugin-commonjs";
+import json from "rollup-plugin-json";
+import { terser } from "rollup-plugin-terser";
+
+function createConfig(entry, out, { minify = false } = {}) {
+  return [
+    {
+      input: entry,
+      output: { file: `${out}.js`, format: "esm" },
+      plugins: [commonjs(), resolve(), json(), minify ? terser() : null]
+    }
+  ];
+}
+
+export default [
+  ...createConfig(`./src/ansi_to_html.js`, "dist/ansi_to_html.esm"),
+  ...createConfig(`./src/ansi_to_html.js`, "dist/ansi_to_html.esm.min", {
+    minify: true
+  })
+];


### PR DESCRIPTION
Hello,

What do you think about using rollup to produce minified version of the library to have a browser-ready build?
I do this following suggestions from https://www.pika.dev/search?q=ansi-to-html 

Thanks,