### PR TITLE
fix when pattern like this 'foo\r\r\n', output will be empty

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -47,6 +47,7 @@ class AnsiToHtmlConverter
         $text = htmlspecialchars($text, PHP_VERSION_ID >= 50400 ? ENT_QUOTES | ENT_SUBSTITUTE : ENT_QUOTES, $this->charset);
 
         // carriage return
+        $text = preg_replace('#\r+#m', "\r", $text);
         $text = preg_replace('#^.*\r(?!\n)#m', '', $text);
 
         $tokens = $this->tokenize($text);

--- a/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
@@ -47,6 +47,7 @@ class AnsiToHtmlConverterTest extends \PHPUnit_Framework_TestCase
             array('<span style="background-color: red; color: red">foo</span>', "\e[31;41;1mfoo\e[0m"),
 
             // carriage returns
+            array('<span style="background-color: black; color: white">foobar\r\nbar</span>', "foo\r\r\nbar"),
             array('<span style="background-color: black; color: white">foobar</span>', "foo\rbar\rfoobar"),
 
             // underline


### PR DESCRIPTION
We found some devices (H3C S10508-V) may output like this:
```shell
blahblahblan \r\r\n
blahblahblan \r\r\n
```

However the history version may covert it into this:
```shell
\r\n
\r\n
```

