### PR TITLE
[PHP 8.4] Change implicit type declaration to nullable types

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -24,7 +24,7 @@ class AnsiToHtmlConverter
     protected $inlineColors;
     protected $colorNames;
 
-    public function __construct(Theme $theme = null, $inlineStyles = true, $charset = 'UTF-8')
+    public function __construct(?Theme $theme = null, $inlineStyles = true, $charset = 'UTF-8')
     {
         $this->theme = null === $theme ? new Theme() : $theme;
         $this->inlineStyles = $inlineStyles;

--- a/SensioLabs/AnsiConverter/Bridge/Twig/AnsiExtension.php
+++ b/SensioLabs/AnsiConverter/Bridge/Twig/AnsiExtension.php
@@ -12,7 +12,7 @@ class AnsiExtension extends AbstractExtension
     /** @var AnsiToHtmlConverter */
     private $converter;
 
-    public function __construct(AnsiToHtmlConverter $converter = null)
+    public function __construct(?AnsiToHtmlConverter $converter = null)
     {
         $this->converter = $converter ?: new AnsiToHtmlConverter();
     }


### PR DESCRIPTION
Hey!

I've recently switched to PHP 8.4 and am using your plugin.
This PR removes two deprecation notices for implicitly nullable types that has been deprecated in PHP 8.4
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

Since this plugin is PHP > 7.2.5, I've used nullable types instead of union types
