### PR TITLE
Multiple improvements to styling and colors

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -95,8 +95,9 @@ class AnsiToHtmlConverter
     {
         $bg = 0;
         $fg = 7;
-        $as = '';
-        $hi = false;
+        $as = ''; // inline styles
+        $cs = ''; // css classes
+        $hi = false; // high intensity
         if ('0' != $ansi && '' != $ansi) {
             $options = explode(';', $ansi);
 
@@ -129,14 +130,17 @@ class AnsiToHtmlConverter
 
             if (in_array(3, $options)) {
                 $as .= '; font-style: italic';
+                $cs .= ' ansi_color_italic';
             }
 
             if (in_array(4, $options)) {
                 $as .= '; text-decoration: underline';
+                $cs .= ' ansi_color_underline';
             }
 
             if (in_array(9, $options)) {
                 $as .= '; text-decoration: line-through';
+                $cs .= ' ansi_color_strikethrough';
             }
 
             if (in_array(7, $options)) {
@@ -149,7 +153,7 @@ class AnsiToHtmlConverter
         if ($this->inlineStyles) {
             return sprintf('</span><span style="background-color: %s; color: %s%s">', $this->inlineColors[$this->colorNames[$bg]], $this->inlineColors[$this->colorNames[$fg]], $as);
         } else {
-            return sprintf('</span><span class="ansi_color_bg_%s ansi_color_fg_%s">', $this->colorNames[$bg], $this->colorNames[$fg]);
+            return sprintf('</span><span class="ansi_color_bg_%s ansi_color_fg_%s%s">', $this->colorNames[$bg], $this->colorNames[$fg], $cs);
         }
     }
 

--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -117,14 +117,26 @@ class AnsiToHtmlConverter
                 }
             }
 
-            // options: bold => 1, underscore => 4, blink => 5, reverse => 7, conceal => 8
+            // options: bold => 1, dim => 2, italic => 3, underscore => 4, blink => 5, rapid blink => 6, reverse => 7, conceal => 8, strikethrough => 9
             if (in_array(1, $options) || $hi) { // high intensity equals regular bold
                 $fg += 10;
                 // bold does not affect background color
             }
 
+            if (in_array(2, $options)) { // dim
+                $fg = ($fg >= 10) ? $fg - 10 : $fg;
+            }
+
+            if (in_array(3, $options)) {
+                $as .= '; font-style: italic';
+            }
+
             if (in_array(4, $options)) {
-                $as = '; text-decoration: underline';
+                $as .= '; text-decoration: underline';
+            }
+
+            if (in_array(9, $options)) {
+                $as .= '; text-decoration: line-through';
             }
 
             if (in_array(7, $options)) {

--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -120,7 +120,7 @@ class AnsiToHtmlConverter
             // options: bold => 1, underscore => 4, blink => 5, reverse => 7, conceal => 8
             if (in_array(1, $options) || $hi) { // high intensity equals regular bold
                 $fg += 10;
-                $bg += 10;
+                // bold does not affect background color
             }
 
             if (in_array(4, $options)) {

--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -96,6 +96,7 @@ class AnsiToHtmlConverter
         $bg = 0;
         $fg = 7;
         $as = '';
+        $hi = false;
         if ('0' != $ansi && '' != $ansi) {
             $options = explode(';', $ansi);
 
@@ -104,6 +105,11 @@ class AnsiToHtmlConverter
                     $fg = $option - 30;
                 } elseif ($option >= 40 && $option < 48) {
                     $bg = $option - 40;
+                } elseif ($option >= 90 && $option < 98) {
+                    $fg = $option - 90;
+                    $hi = true;
+                } elseif ($option >= 100 && $option < 108) {
+                    $bg = $option - 90;
                 } elseif (39 == $option) {
                     $fg = 7;
                 } elseif (49 == $option) {
@@ -112,7 +118,7 @@ class AnsiToHtmlConverter
             }
 
             // options: bold => 1, underscore => 4, blink => 5, reverse => 7, conceal => 8
-            if (in_array(1, $options)) {
+            if (in_array(1, $options) || $hi) { // high intensity equals regular bold
                 $fg += 10;
                 $bg += 10;
             }

--- a/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
@@ -52,6 +52,27 @@ class AnsiToHtmlConverterTest extends \PHPUnit_Framework_TestCase
             // underline
             array('<span style="background-color: black; color: white; text-decoration: underline">foo</span>', "\e[4mfoo\e[0m"),
 
+            // italic
+            array('<span style="background-color: black; color: white; font-style: italic">foo</span>', "\e[3mfoo\e[0m"),
+
+            // strikethrough
+            array('<span style="background-color: black; color: white; text-decoration: line-through">foo</span>', "\e[9mfoo\e[0m"),
+
+            // high intensity = normal bold
+            array('<span style="background-color: black; color: red">foo</span>', "\e[91mfoo\e[0m"),
+
+            // high intensity dimmed = normal
+            array('<span style="background-color: black; color: darkred">foo</span>', "\e[2;91mfoo\e[0m"),
+
+            // high intensity background
+            array('<span style="background-color: magenta; color: white">foo</span>', "\e[105mfoo\e[0m"),
+
+            // bold and background (bold does not affect background color)
+            array('<span style="background-color: darkred; color: lightcyan">foo</span>', "\e[1;41;36mfoo\e[0m"),
+
+            // bold and background (high intensity)
+            array('<span style="background-color: red; color: lightcyan">foo</span>', "\e[1;101;96mfoo\e[0m"),
+
             // non valid unicode codepoints substitution (only available with PHP >= 5.4)
             PHP_VERSION_ID < 50400 ?: array('<span style="background-color: black; color: white">foo '."\xEF\xBF\xBD".'</span>', "foo \xF4\xFF\xFF\xFF"),
         );

--- a/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
@@ -44,7 +44,7 @@ class AnsiToHtmlConverterTest extends \PHPUnit_Framework_TestCase
             array('<span style="background-color: darkred; color: darkred">foo</span>', "\e[31;41mfoo\e[m"),
 
             // bright color
-            array('<span style="background-color: red; color: red">foo</span>', "\e[31;41;1mfoo\e[0m"),
+            array('<span style="background-color: darkred; color: red">foo</span>', "\e[31;41;1mfoo\e[0m"),
 
             // carriage returns
             array('<span style="background-color: black; color: white">foobar</span>', "foo\rbar\rfoobar"),

--- a/SensioLabs/AnsiConverter/Theme/AnsiTheme.php
+++ b/SensioLabs/AnsiConverter/Theme/AnsiTheme.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of ansi-to-html.
+ *
+ * (c) 2013 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\AnsiConverter\Theme;
+
+/**
+ * This theme uses ANSI-like colors.
+ */
+class AnsiTheme extends Theme
+{
+    public function asArray()
+    {
+        return array(
+            // normal
+            'black' => '#000000',
+            'red' => '#AA0000',
+            'green' => '#00AA00',
+            'yellow' => '#AAAA00',
+            'blue' => '#0000AA',
+            'magenta' => '#AA00AA',
+            'cyan' => '#00AAAA',
+            'white' => '#AAAAAA',
+
+            // bright
+            'brblack' => '#555555',
+            'brred' => '#FF5555',
+            'brgreen' => '#55FF55',
+            'bryellow' => '#FFFF55',
+            'brblue' => '#5555FF',
+            'brmagenta' => '#FF55FF',
+            'brcyan' => '#55FFFF',
+            'brwhite' => '#FFFFFF',
+        );
+    }
+}

--- a/SensioLabs/AnsiConverter/Theme/Theme.php
+++ b/SensioLabs/AnsiConverter/Theme/Theme.php
@@ -24,6 +24,10 @@ class Theme
             $css[] = sprintf('.%s_bg_%s { background-color: %s }', $prefix, $name, $color);
         }
 
+        $css[] = sprintf('.%s_italic { font-style: italic }', $prefix);
+        $css[] = sprintf('.%s_underline { text-decoration: underline }', $prefix);
+        $css[] = sprintf('.%s_strikethrough { text-decoration: line-through }', $prefix);
+
         return implode("\n", $css);
     }
 


### PR DESCRIPTION
This PR does few things:
- implements support for high intensity colors (https://github.com/sensiolabs/ansi-to-html/issues/22)
- stops bold ansi code from affecting background color, this does not happen in the terminal
- adds support for dim, italic and strikethrough codes
  - dim implemented by reducing color index by 10, alternative would be `filter: brightness(0.5)` but it also affects background too... so no go
- adds font styling to css (underline was already missing)
- adds a Terminal/Console like theme using colors looking closely to the ANSI ones
  - NOT set as default

<details>
<summary>Visual comparison</summary>

### Colors comparison:

![comparison](https://github.com/user-attachments/assets/c8a9dc1b-480c-4910-b836-9c4970a87c2b)

### All styling options (default theme on the left, new theme on the right):

![all options default comparison](https://github.com/user-attachments/assets/bd081425-5acd-4b97-a072-6f31e5564760)

</details>

Tests run with PHPUnit 9.6.22 after patching the class:
<details>
<summary>Used patch</summary>

```diff
--- a/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
@@ -13,7 +13,7 @@ namespace SensioLabs\AnsiConverter\Tests;
 
 use SensioLabs\AnsiConverter\AnsiToHtmlConverter;
 
-class AnsiToHtmlConverterTest extends \PHPUnit_Framework_TestCase
+class AnsiToHtmlConverterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getConvertData
@@ -24,7 +24,7 @@ class AnsiToHtmlConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $converter->convert($input));
     }
 
-    public function getConvertData()
+    public static function getConvertData()
     {
         return array(
             // text is escaped
```
</details>

Did not test with newer PHPUnit versions.

