### PR TITLE
Handle multiple codes in sequences

### DIFF
--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -99,7 +99,7 @@ class AnsiToHtmlConverter
         if ('0' != $ansi && '' != $ansi) {
             $options = explode(';', $ansi);
 
-            foreach ($options as $option) {
+            foreach ($options as $key => $option) {
                 if ($option >= 30 && $option < 38) {
                     $fg = $option - 30;
                 } elseif ($option >= 40 && $option < 48) {
@@ -108,6 +108,22 @@ class AnsiToHtmlConverter
                     $fg = 7;
                 } elseif (49 == $option) {
                     $bg = 0;
+                } elseif ($option >= 22 && $option < 30) { // 21 has varying effects, best to ignored it
+                    $unset = $option - 20;
+
+                    foreach ($options as $i => $v) {
+                        if ($v == $unset) {
+                            unset($options[$i]);
+                        }
+
+                        if (2 == $unset && 1 == $v) { // 22 also unsets bold
+                            unset($options[$i]);
+                        }
+
+                        if ($i >= $key) { // do not unset options after current position in parent loop
+                            break;
+                        }
+                    }
                 }
             }
 

--- a/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
@@ -54,6 +54,9 @@ class AnsiToHtmlConverterTest extends \PHPUnit_Framework_TestCase
 
             // non valid unicode codepoints substitution (only available with PHP >= 5.4)
             PHP_VERSION_ID < 50400 ?: array('<span style="background-color: black; color: white">foo '."\xEF\xBF\xBD".'</span>', "foo \xF4\xFF\xFF\xFF"),
+
+            // codes in sequence - remember enabled styling like bold, italic, etc. (until we hit a reset)
+            array('<span style="background-color: black; color: lightgreen">foo</span><span style="background-color: black; color: lightgreen">bar</span><span style="background-color: black; color: white">foo</span>', "\e[1;32mfoo\e[32mbar\e[mfoo"),
         );
     }
 }


### PR DESCRIPTION
This PR adds support for handling multiple sequences of ansi codes - preserving the styling until reset code is found.

This addresses https://github.com/sensiolabs/ansi-to-html/issues/17

### Current:
![sequences current](https://github.com/user-attachments/assets/9ba757d8-cc92-4e44-8a68-c5dfff22469e)

### With this PR:
![sequences pr](https://github.com/user-attachments/assets/fdc5fb5e-1d92-4683-8543-0673441b360b)

Like in my other PR, PHPUnit passes once the test class is fixed.

## TODO: 
~~ANSI codes 22-29 should disable appropriate styling, currently it will not work because of `in_array` checks on 1-9, might need to remove values directly in `tokenize` or rewrite the styling code into something else
**I have an idea how to approach this, will update on that soon**~~ Done