### PR TITLE
Add missing type hints & validate PHPStan level 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $twig->addExtension(new AnsiExtension($converter));
 
 Then:
 
-```jinja
+```twig
 <html>
     <head>
         <style>

--- a/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
+++ b/SensioLabs/AnsiConverter/AnsiToHtmlConverter.php
@@ -18,7 +18,14 @@ use SensioLabs\AnsiConverter\Theme\Theme;
  */
 class AnsiToHtmlConverter
 {
+    /**
+     * @var array<string, string>
+     */
     protected array $inlineColors;
+
+    /**
+     * @var array<string>
+     */
     protected array $colorNames;
 
     public function __construct(
@@ -36,24 +43,25 @@ class AnsiToHtmlConverter
 
     public function convert(string $text): string
     {
-        // remove cursor movement sequences
-        $text = preg_replace('#\e\[(K|s|u|2J|2K|\d+(A|B|C|D|E|F|G|J|K|S|T)|\d+;\d+(H|f))#', '', $text);
-        // remove character set sequences
-        $text = preg_replace('#\e(\(|\))(A|B|[0-2])#', '', $text);
+        $text = preg_replace([
+            // remove cursor movement sequences
+            '#\e\[(K|s|u|2J|2K|\d+(A|B|C|D|E|F|G|J|K|S|T)|\d+;\d+(H|f))#',
+            // remove character set sequences
+            '#\e(\(|\))(A|B|[0-2])#',
+            // remove carriage return
+            '#^.*\r(?!\n)#m',
+        ], '', $text) ?? '';
 
-        $text = htmlspecialchars($text, \PHP_VERSION_ID >= 50400 ? \ENT_QUOTES | \ENT_SUBSTITUTE : \ENT_QUOTES, $this->charset);
-
-        // carriage return
-        $text = preg_replace('#^.*\r(?!\n)#m', '', $text);
+        $text = htmlspecialchars($text, \ENT_QUOTES | \ENT_SUBSTITUTE, $this->charset);
 
         $tokens = $this->tokenize($text);
 
         // a backspace remove the previous character but only from a text token
         foreach ($tokens as $i => $token) {
-            if ('backspace' == $token[0]) {
+            if ('backspace' === $token[0]) {
                 $j = $i;
                 while (--$j >= 0) {
-                    if ('text' == $tokens[$j][0] && '' !== $tokens[$j][1]) {
+                    if ('text' === $tokens[$j][0] && '' !== $tokens[$j][1]) {
                         $tokens[$j][1] = substr($tokens[$j][1], 0, -1);
 
                         break;
@@ -64,9 +72,9 @@ class AnsiToHtmlConverter
 
         $html = '';
         foreach ($tokens as $token) {
-            if ('text' == $token[0]) {
+            if ('text' === $token[0]) {
                 $html .= $token[1];
-            } elseif ('color' == $token[0]) {
+            } elseif ('color' === $token[0]) {
                 $html .= $this->convertAnsiToColor($token[1]);
             }
         }
@@ -78,9 +86,7 @@ class AnsiToHtmlConverter
         }
 
         // remove empty span
-        $html = preg_replace('#<span[^>]*></span>#', '', $html);
-
-        return $html;
+        return preg_replace('#<span[^>]*></span>#', '', $html) ?? '';
     }
 
     public function getTheme(): Theme
@@ -95,7 +101,7 @@ class AnsiToHtmlConverter
         $as = ''; // inline styles
         $cs = ''; // css classes
         $hi = false; // high intensity
-        if ('0' != $ansi && '' != $ansi) {
+        if ('0' !== $ansi && '' !== $ansi) {
             $options = explode(';', $ansi);
 
             foreach ($options as $key => $option) {
@@ -109,19 +115,21 @@ class AnsiToHtmlConverter
                     $hi = true;
                 } elseif ($option >= 100 && $option < 108) {
                     $bg = $option - 90;
-                } elseif (39 == $option) {
+                } elseif (39 === $option) {
                     $fg = 7;
-                } elseif (49 == $option) {
+                } elseif (49 === $option) {
                     $bg = 0;
                 } elseif ($option >= 22 && $option < 30) { // 21 has varying effects, best to ignored it
                     $unset = $option - 20;
 
                     foreach ($options as $i => $v) {
-                        if ($v == $unset) {
+                        $v = (int) $v;
+
+                        if ($v === $unset) {
                             unset($options[$i]);
                         }
 
-                        if (2 == $unset && 1 == $v) { // 22 also unsets bold
+                        if (2 === $unset && 1 === $v) { // 22 also unsets bold
                             unset($options[$i]);
                         }
 
@@ -171,6 +179,11 @@ class AnsiToHtmlConverter
         }
     }
 
+    /**
+     * Tokenizes the given text into an array of tokens.
+     *
+     * @return list<array<int, string>>
+     */
     protected function tokenize(string $text): array
     {
         $tokens = [];
@@ -184,7 +197,7 @@ class AnsiToHtmlConverter
             }
 
             foreach (explode(';', $matches[1][$i][0]) as $code) {
-                if ('0' == $code || '' == $code) {
+                if ('0' === $code || '' === $code) {
                     $codes = [];
                 } else {
                     // remove existing occurrence to avoid processing duplicate styles
@@ -196,7 +209,7 @@ class AnsiToHtmlConverter
                 $codes[] = $code;
             }
 
-            $tokens[] = ["\x08" == $match[0] ? 'backspace' : 'color', implode(';', $codes)];
+            $tokens[] = ["\x08" === $match[0] ? 'backspace' : 'color', implode(';', $codes)];
             $offset = $match[1] + \strlen($match[0]);
         }
 

--- a/SensioLabs/AnsiConverter/Bridge/Twig/AnsiExtension.php
+++ b/SensioLabs/AnsiConverter/Bridge/Twig/AnsiExtension.php
@@ -37,6 +37,11 @@ class AnsiExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
     public function ansiToHtml($string)
     {
         return $this->converter->convert($string);

--- a/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
+++ b/SensioLabs/AnsiConverter/Tests/AnsiToHtmlConverterTest.php
@@ -24,6 +24,9 @@ class AnsiToHtmlConverterTest extends TestCase
         $this->assertEquals($expected, $converter->convert($input));
     }
 
+    /**
+     * @return array<list<string>>
+     */
     public static function getConvertData(): array
     {
         return [
@@ -73,8 +76,8 @@ class AnsiToHtmlConverterTest extends TestCase
             // bold and background (high intensity)
             ['<span style="background-color: red; color: lightcyan">foo</span>', "\e[1;101;96mfoo\e[0m"],
 
-            // non valid unicode codepoints substitution (only available with PHP >= 5.4)
-            \PHP_VERSION_ID < 50400 ?: ['<span style="background-color: black; color: white">foo '."\xEF\xBF\xBD".'</span>', "foo \xF4\xFF\xFF\xFF"],
+            // non valid unicode codepoints substitution
+            ['<span style="background-color: black; color: white">foo '."\xEF\xBF\xBD".'</span>', "foo \xF4\xFF\xFF\xFF"],
 
             // codes in sequence - remember enabled styling like bold, italic, etc. (until we hit a reset)
             ['<span style="background-color: black; color: lightgreen">foo</span><span style="background-color: black; color: lightgreen">bar</span><span style="background-color: black; color: white">foo</span>', "\e[1;32mfoo\e[32mbar\e[mfoo"],

--- a/SensioLabs/AnsiConverter/Theme/Theme.php
+++ b/SensioLabs/AnsiConverter/Theme/Theme.php
@@ -31,6 +31,9 @@ class Theme
         return implode("\n", $css);
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function asArray(): array
     {
         return [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,8 @@
 parameters:
-    level: 3
+    level: 9
     paths:
         - SensioLabs
+    ignoreErrors:
+        - 
+            message: '#Method [a-zA-Z0-9\\_]+Test::[a-zA-Z0-9]+\(\) has no return type specified.#'
+            path: SensioLabs/AnsiConverter/Tests/*


### PR DESCRIPTION
**TL;DR;** stricter type checks + PHPDoc annotations = PHPStan level 9

### AnsiToHtmlConverter

* Grouped `preg_replace` calls into a single call in `AnsiToHtmlConverter::convert`
* Removed a conditional test case for PHP versions below 5.4
* Strict comparaisons
* PHPDoc annotations

### AnsiToHtmlConverterTest

* Removed a conditional test case for PHP versions below 5.4
* PHPDoc annotations
